### PR TITLE
FEST-241: created workaround for bug when saving deeply nested has ma…

### DIFF
--- a/addon/mixins/model.js
+++ b/addon/mixins/model.js
@@ -4,6 +4,7 @@ import EmberObject from '@ember/object';
 import { A } from '@ember/array';
 import { defineProperty } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
+import { isPresent } from '@ember/utils';
 
 const resetRelations = function(record) {
   Object.keys(record.get('__recordsJustSaved') || {}).forEach((relationName) => {
@@ -12,7 +13,9 @@ const resetRelations = function(record) {
     relationRecords.forEach((r) => {
       let shouldUnload = r.get('isNew') || r.get('markedForDestruction');
       if (shouldUnload) {
-        record.get(relationName).removeObject(r);
+        if (isPresent(record.get(relationName))) {
+          record.get(relationName).removeObject(r);
+        }
         r.unloadRecord();
       } else if (r.get('markedForDeletion')) {
         record.get(relationName).removeObject(r);

--- a/tests/dummy/app/models/description.js
+++ b/tests/dummy/app/models/description.js
@@ -4,5 +4,5 @@ import ModelMixin from 'ember-data-extensions/mixins/model';
 export default DS.Model.extend(ModelMixin, {
   name: DS.attr('string'),
 
-  descriptions: DS.hasMany('description')
+  tag: DS.belongsTo('tag')
 });

--- a/tests/dummy/mirage/models/description.js
+++ b/tests/dummy/mirage/models/description.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  tag: belongsTo()
+});

--- a/tests/dummy/mirage/models/tag.js
+++ b/tests/dummy/mirage/models/tag.js
@@ -1,5 +1,6 @@
-import { Model, belongsTo } from 'ember-cli-mirage';
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
-  post: belongsTo()
+  post: belongsTo(),
+  descriptions: hasMany()
 });

--- a/tests/unit/mixins/model-test.js
+++ b/tests/unit/mixins/model-test.js
@@ -1,6 +1,7 @@
 import { setupTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { run } from '@ember/runloop';
+import { A } from '@ember/array';
 import { module, test } from 'qunit';
 
 const seedPost = function(store) {
@@ -111,5 +112,26 @@ module('Unit | Mixin | model', function(hooks) {
         done2();
       });
     });
+  });
+
+  test('it should correctly save deeply nested has many relations', async function(assert) {
+    assert.expect(1);
+
+    server.post('/posts', {
+      data: {
+        id: 1,
+        type: 'posts'
+      }
+    });
+
+    let store = this.owner.lookup('service:store');
+    let post = store.createRecord('post');
+    let tag = store.createRecord('tag');
+    let description = store.createRecord('description');
+
+    tag.set('descriptions', A([description]));
+    post.set('tags', A([tag]));
+    await post.save({ adapterOptions: { relationships: ['tags', { tags: 'descriptions' }] } });
+    assert.ok(true);
   });
 });


### PR DESCRIPTION
…ny relation

**Summary:**
This is just a work-around. I believe the root of the issue is in the `nested-relations` mixin, in the `hasMany` function.

**Description:**
Assume we have the relationships below for a `tag`.
```
post: belongsTo('post'),
descriptions: hasMany('description')
```
In the `hasMany` function, we push into the object `savedRecords` any `hasMany` relationship in our example, the `descriptions` relationship. This `savedRecords` object is later used to unload records from the parent record, so in our example, will look up `descriptions` on `post`, which is an invalid relationship.

**Solutions:**
1. Use this as a work around
2. Update the `hasMany` function to ignore deeply nested `hasMany` relationships