### PR TITLE
Remove unloaded objects from nested relationshps

### DIFF
--- a/addon/mixins/model.js
+++ b/addon/mixins/model.js
@@ -10,15 +10,19 @@ const resetRelations = function(record) {
   Object.keys(record.get('__recordsJustSaved') || {}).forEach((relationName) => {
     let relationRecords = record.get('__recordsJustSaved')[relationName];
 
-    relationRecords.forEach((r) => {
+    relationRecords.forEach(({ parent, relatedRecord }) => {
+      let r = relatedRecord;
       let shouldUnload = r.get('isNew') || r.get('markedForDestruction');
+      let relation = parent.get(relationName);
       if (shouldUnload) {
-        if (isPresent(record.get(relationName))) {
-          record.get(relationName).removeObject(r);
+        if (isPresent(relation)) {
+          relation.removeObject(r);
         }
         r.unloadRecord();
       } else if (r.get('markedForDeletion')) {
-        record.get(relationName).removeObject(r);
+        if (isPresent(relation)) {
+          relation.removeObject(r);
+        }
         r.set('markedForDeletion', false);
       }
     });

--- a/addon/mixins/nested-relations.js
+++ b/addon/mixins/nested-relations.js
@@ -116,7 +116,7 @@ const addToIncludes = function(payload, includedRecords) {
   }
 };
 
-const hasManyData = function(relationName, relatedRecords, subRelations, manyToManyDeleted, includedRecords) {
+const hasManyData = function(parent, relationName, relatedRecords, subRelations, manyToManyDeleted, includedRecords) {
   let payloads = [];
   savedRecords[relationName] = [];
 
@@ -126,7 +126,7 @@ const hasManyData = function(relationName, relatedRecords, subRelations, manyToM
     addToIncludes(payload, includedRecords);
 
     payloads.push(payloadForRelationship(payload));
-    savedRecords[relationName].push(relatedRecord);
+    savedRecords[relationName].push({ parent, relatedRecord });
   });
   return { data: payloads };
 };
@@ -139,11 +139,11 @@ const belongsToData = function(relatedRecord, subRelations, includedRecords) {
   return { data: payloadForRelationship(payload) };
 };
 
-const processRelationship = function(name, kind, relationData, subRelations, manyToManyDeleted, includedRecords, callback) {
+const processRelationship = function(parent, name, kind, relationData, subRelations, manyToManyDeleted, includedRecords, callback) {
   let payload = null;
 
   if (kind === 'hasMany') {
-    payload = hasManyData(name, relationData, subRelations, manyToManyDeleted, includedRecords);
+    payload = hasManyData(parent, name, relationData, subRelations, manyToManyDeleted, includedRecords);
   } else {
     payload = belongsToData(relationData, subRelations, includedRecords);
   }
@@ -158,7 +158,7 @@ const processRelationships = function(relationshipHash, jsonData, record, includ
     jsonData.relationships = {};
 
     iterateRelations(record, relationshipHash, (name, kind, related, subRelations, manyToManyDeleted) => {
-      processRelationship(name, kind, related, subRelations, manyToManyDeleted, includedRecords, (payload) => {
+      processRelationship(record, name, kind, related, subRelations, manyToManyDeleted, includedRecords, (payload) => {
         let serializer = record.store.serializerFor(record.constructor.modelName);
         let serializedName = serializer.keyForRelationship(name);
         jsonData.relationships[serializedName] = payload;

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -128,5 +128,6 @@ export default function() {
 
   this.get('/authors/:id');
   this.get('/tags/:id');
+  this.get('/descriptions/:id');
   this.get('/tags');
 }


### PR DESCRIPTION
### Explanation of the issue

Let's say we have nested objects to save:

```
event: [shows: [tickets]]
```

and we create a new ticket (which belongs to the show).

In that case, the reset relationships function doesn't remove the created in the store record from the list of tickets.

Before save:

```
show.tickets.mapBy('id') // => [1,2]
```

after save:

```
show.tickets.mapBy('id') // => [1,2,3, null]
```

### The explanation of the fix

Now, we properly remove the `null` object from the relationships and unload it.

Basically, we just had to remove that from the correct parent. Before, the extension was trying to remove `ticket` from top-level object (i.e. `event`)



